### PR TITLE
Class split by  regex to catch double spaces, new lines, etc.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function (options) {
     return function posthtmlPrefixClass(tree) {
         return tree.walk(function (node) {
             var attrs = node.attrs || false;
-            var classNames = attrs.class && attrs.class.split(' ');
+            var classNames = attrs.class && attrs.class.split('/\s+/');
 
             if (!classNames) {
                 return node;

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function (options) {
     return function posthtmlPrefixClass(tree) {
         return tree.walk(function (node) {
             var attrs = node.attrs || false;
-            var classNames = attrs.class && attrs.class.split('/\s+/');
+            var classNames = attrs.class && attrs.class.trim().split(/\s+/g);
 
             if (!classNames) {
                 return node;


### PR DESCRIPTION
Replaced class split by space with regular expression to catch double spaces, new lines, etc.

Before that I got weird results like:  
**Source**
`<div class="class1     class2">`

**Output**
`<div class="prefix-class1 prefix- prefix- prefix-class2">`

Now works fine:

**Output**
`<div class="prefix-class1     prefix-class2">`
